### PR TITLE
resolve issue with deep imports in ng9+ production builds

### DIFF
--- a/packages/aws-amplify-angular/src/providers/amplify.service.ts
+++ b/packages/aws-amplify-angular/src/providers/amplify.service.ts
@@ -14,8 +14,7 @@
 // tslint:enable
 
 import { Injectable, Optional, Inject } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
+import { Subject, Observable } from 'rxjs';
 import Amplify, { Logger, I18n } from '@aws-amplify/core';
 import { AuthState } from './auth.state';
 import { authDecorator } from './auth.decorator';


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Angular 9 and 10 issues a warning about deep imports of rxjs/Subject. This doesnt seem to cause issues when running in dev mode, but breaks a production build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
